### PR TITLE
feat: allow public methods in http server by configuration from port

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -245,7 +245,8 @@ module.exports = function(port) {
             request.payload.method === 'identity.forgottenPasswordValidate' ||
             request.payload.method === 'identity.forgottenPassword' ||
             request.payload.method === 'identity.registerRequest' ||
-            request.payload.method === 'identity.registerValidate'
+            request.payload.method === 'identity.registerValidate' ||
+            port.config.publicMethods && port.config.publicMethods.indexOf(request.payload.method) > -1
         ) {
             return processMessage();
         }

--- a/handlers.js
+++ b/handlers.js
@@ -241,11 +241,6 @@ module.exports = function(port) {
                 ))
             });
         } else if (
-            request.payload.method === 'identity.forgottenPasswordRequest' ||
-            request.payload.method === 'identity.forgottenPasswordValidate' ||
-            request.payload.method === 'identity.forgottenPassword' ||
-            request.payload.method === 'identity.registerRequest' ||
-            request.payload.method === 'identity.registerValidate' ||
             port.config.publicMethods && port.config.publicMethods.indexOf(request.payload.method) > -1
         ) {
             return processMessage();

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function HttpServerPort() {
                 }
             }
         },
-        publicRoutes: [
+        publicMethods: [
             'identity.forgottenPasswordRequest',
             'identity.forgottenPasswordValidate',
             'identity.forgottenPassword',

--- a/index.js
+++ b/index.js
@@ -41,6 +41,13 @@ function HttpServerPort() {
                 }
             }
         },
+        publicRoutes: [
+            'identity.forgottenPasswordRequest',
+            'identity.forgottenPasswordValidate',
+            'identity.forgottenPassword',
+            'identity.registerRequest',
+            'identity.registerValidate'
+        ],
         cookie: {
             ttl: 100 * 60 * 1000, // expires a year from today
             encoding: 'none', // we already used JWT to encode


### PR DESCRIPTION
At the moment we are seting the public methods directly in ut-port-httpserver. I believe the httpserver port should be able to receive the list of public methods from the port and handle it implementation specific.