### PR TITLE
Out of band authentication

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -299,10 +299,11 @@ module.exports = function(port) {
             )}
         );
 
-        if (port.bus.config.outOfBandAuthentication &&
-            port.bus.config.outOfBandAuthentication.protectedMethods.indexOf(request.params.method) >= 0) {
+        if (port.config.outOfBandAuthentication &&
+            port.config.outOfBandAuthentication.protectedMethods.indexOf(request.params.method) >= 0) {
             assign(
                 identityCheckParams, {
+                    requiresOobValidation: true,
                     oobPayload: request.headers['x-oob'],
                     oobInstallationId: request.headers['x-installation-id']
                 }

--- a/handlers.js
+++ b/handlers.js
@@ -296,11 +296,7 @@ module.exports = function(port) {
                 (port.config.allowXFF && request.headers['x-forwarded-for'])
                 ? request.headers['x-forwarded-for']
                 : request.info.remoteAddress
-            )},
-            {oob: {
-                payload: request.headers['x-oob'],
-                installationId: request.headers['x-installation-id']
-            }}
+            )}
         );
 
         Promise.resolve()
@@ -310,7 +306,16 @@ module.exports = function(port) {
                     'permission.get': ['*']
                 };
             }
-            return port.bus.importMethod(identityCheckFullName)(identityCheckParams);
+            var $meta = {
+                auth: request.auth.credentials,
+                method: request.payload.method,
+                opcode: request.payload.method.split('.').pop(),
+                mtid: (request.payload.id == null) ? 'notification' : 'request',
+                requestHeaders: request.headers,
+                ipAddress: request.info && request.info.remoteAddress,
+                frontEnd: request.headers && request.headers['user-agent']
+            };
+            return port.bus.importMethod(identityCheckFullName)(identityCheckParams, $meta);
         })
         .then((res) => {
             if (request.payload.method === identityCheckFullName) {

--- a/handlers.js
+++ b/handlers.js
@@ -296,19 +296,12 @@ module.exports = function(port) {
                 (port.config.allowXFF && request.headers['x-forwarded-for'])
                 ? request.headers['x-forwarded-for']
                 : request.info.remoteAddress
-            )}
+            )},
+            {oob: {
+                payload: request.headers['x-oob'],
+                installationId: request.headers['x-installation-id']
+            }}
         );
-
-        if (port.config.outOfBandAuthentication &&
-            port.config.outOfBandAuthentication.protectedMethods.indexOf(request.params.method) >= 0) {
-            assign(
-                identityCheckParams, {
-                    requiresOobValidation: true,
-                    oobPayload: request.headers['x-oob'],
-                    oobInstallationId: request.headers['x-installation-id']
-                }
-            );
-        }
 
         Promise.resolve()
         .then(() => {

--- a/handlers.js
+++ b/handlers.js
@@ -186,6 +186,9 @@ module.exports = function(port) {
                 if (msgOptions.language) {
                     $meta.language = msgOptions.language;
                 }
+                if (msgOptions.protection) {
+                    $meta.protection = msgOptions.protection;
+                }
                 var callback = function(response) {
                     if (!response) {
                         throw new Error('Add return value of method ' + request.payload.method);
@@ -341,7 +344,8 @@ module.exports = function(port) {
             } else {
                 if (res['permission.get'] && res['permission.get'].length) {
                     return processMessage({
-                        language: res.language
+                        language: res.language,
+                        protection: res.protection
                     });
                 } else {
                     return handleError(errors.NotPermitted(`Missing Permission for ${request.payload.method}`));

--- a/handlers.js
+++ b/handlers.js
@@ -299,6 +299,16 @@ module.exports = function(port) {
             )}
         );
 
+        if (port.bus.config.outOfBandAuthentication &&
+            port.bus.config.outOfBandAuthentication.protectedMethods.indexOf(request.params.method) >= 0) {
+            assign(
+                identityCheckParams, {
+                    oobPayload: request.headers['x-oob'],
+                    oobInstallationId: request.headers['x-installation-id']
+                }
+            );
+        }
+
         Promise.resolve()
         .then(() => {
             if (port.config.identityNamespace === false || (request.payload.method !== identityCheckFullName && request.route.settings.app.skipIdentityCheck === true)) {


### PR DESCRIPTION
The idea is to define oob-protected methods in the implementation config.
When a oob-protected method is called, the headers should contain encrypted OOB info and installationId.
This info is passed to identity.check for validation.