### PR TITLE
fix: check permission without 'db/' prefix

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -122,7 +122,12 @@ module.exports = function(port) {
         if (request.payload.method === identityCheckFullName) {
             identityCheckParams = assign({}, request.payload.params);
         } else {
-            identityCheckParams = { actionId: request.payload.method };
+            let requestMethodName = request.payload.method;
+            let dbPrefix = 'db/';
+            if (requestMethodName.startsWith(dbPrefix)) {
+                requestMethodName = requestMethodName.substr(dbPrefix.length); // remove 'db/'
+            }
+            identityCheckParams = { actionId: requestMethodName };
         }
         assign(
             identityCheckParams,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-httpserver",
-  "version": "8.10.1",
+  "version": "8.10.2-check-method-permission.0",
   "dependencies": {
     "fs-plus": "2.9.3",
     "hapi": "16.0.2",


### PR DESCRIPTION
Remove the need of both permissions (db/procedureName, procedureName) when calling db/procedureName. With this fix only permissions for procedureNames are necessary